### PR TITLE
fixed a bug with the way we handle errors from the DREAMS API. Should…

### DIFF
--- a/app/utils/error.handler.js
+++ b/app/utils/error.handler.js
@@ -1,7 +1,7 @@
 var q = require('q');
 
 exports.getHttpError = function(statusCode) {
-    return q.promise(function(resolve, reject) {
+    return q.promise(function(resolve) {
         var error = new Error();
         error.status = statusCode;
         switch(statusCode) {
@@ -24,5 +24,14 @@ exports.getHttpError = function(statusCode) {
                 break;
         }
         return resolve(error);
+    });
+};
+
+// response[0]: The response
+// response[1]: The body
+exports.getDREAMSHttpError = function(response) {
+    return q.promise(function(resolve) {
+        response[1].status = response[0].statusCode;
+        return resolve(response[1]);
     });
 };

--- a/app/utils/response.handler.js
+++ b/app/utils/response.handler.js
@@ -1,7 +1,6 @@
 var q = require('q');
 var errorHandler = require('./error.handler');
 
-
 // PARSING
 // ============================================================================
 exports.parsePolyQuery = function(body) {
@@ -23,16 +22,15 @@ exports.parseMonoQuery = function(body) {
 
 // response[0]: the response
 // response[1]: the body
-// response[2]: the error
 exports.parseResponse = function(response) {
     return q.promise(function(resolve, reject) {
         if (!response) {
             return errorHandler.getHttpError(406)
                 .then(reject);
         }
-        if (response[2]) {
-            //TODO: does this ever get called?
-            return reject(response[2]);
+        if (response[1].error) {
+            return errorHandler.getDREAMSHttpError(response)
+                .then(reject);
         }
         return resolve(response);
     });


### PR DESCRIPTION
… now always rejects the error upon parsing

closes #77
