### PR TITLE
need to use public host for the api

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,3 +1,3 @@
 {
-    "API_URL": "http://localhost:3232/api/"
+    "API_URL": "http://xyz.softhouse.se/api/"
 }


### PR DESCRIPTION
After further talk with a guy from the team responsible for the initial development of laughing batman and xyz, we decided to go with a public port: the headers will stick anyhow.
