### PR TITLE
Added a 'hidden' field to users. 

### DIFF
--- a/app/chains/user/user.controller.js
+++ b/app/chains/user/user.controller.js
@@ -23,6 +23,7 @@ function getUserTemplate(name, email) {
         email: email,
         name: name,
         role: 'user',
+        hidden: false,
 
         phoneNumber: null,
         employeeNumber: null,

--- a/app/chains/user/user.routes.js
+++ b/app/chains/user/user.routes.js
@@ -44,7 +44,7 @@ module.exports = function(routes) {
     });
 
     // update a user given an id and an object
-    routes.put('/:id', authentication.isAllowedOrSelf('canEditUser'), authentication.checkForForbiddenFields(['hidden'], ['canEditUser']), function(request, response) {
+    routes.put('/:id', authentication.isAllowedOrSelf('canEditUser'), authentication.checkForForbiddenFields(['hidden', 'email', 'role'], ['canEditUser']), function(request, response) {
         userController.updateUser(request.params.id, request.body, request.headers['x-forwarded-email'])
             .then(responseHandler.sendSuccessfulPutJsonResponse(response))
             .catch(responseHandler.sendErrorResponse(response));

--- a/app/chains/user/user.routes.js
+++ b/app/chains/user/user.routes.js
@@ -13,6 +13,8 @@ module.exports = function(routes) {
     // get users
     routes.get('/', function(request, response) {
         userController.getAllUsers()
+            .then(authenticationHandler.filterHiddenEntities(request.headers['x-forwarded-email'], ['canEditUser']))
+            .then(authenticationHandler.trimManyByattributes(request.headers['x-forwarded-email'], ['canViewUser', 'canEditUser']))
             .then(responseHandler.sendJsonResponse(response))
             .catch(responseHandler.sendErrorResponse(response));
     });
@@ -27,21 +29,22 @@ module.exports = function(routes) {
     //get user by id
     routes.get('/:id', function(request, response) {
         userController.getUserById(request.params.id)
-            .then(authenticationHandler.trimByAttributes(request.headers['x-forwarded-email'], ['canViewProfile', 'canEditProfile']))
+            .then(authenticationHandler.blockHidden(request.headers['x-forwarded-email'], ['canEditUser']))
+            .then(authenticationHandler.trimByAttributes(request.headers['x-forwarded-email'], ['canViewUser', 'canEditUser']))
             .then(responseHandler.sendJsonResponse(response))
             .catch(responseHandler.sendErrorResponse(response));
 
     });
 
     // delete a user given an id
-    routes.delete('/:id', authentication.isAllowedOrSelf('canEditProfile'), function(request, response) {
+    routes.delete('/:id', authentication.isAllowedOrSelf('canEditUser'), function(request, response) {
         userController.deleteUserById(request.params.id)
             .then(responseHandler.sendSuccessfulDeleteJsonResponse(response))
             .catch(responseHandler.sendErrorResponse(response));
     });
 
     // update a user given an id and an object
-    routes.put('/:id', authentication.isAllowedOrSelf('canEditProfile'), function(request, response) {
+    routes.put('/:id', authentication.isAllowedOrSelf('canEditUser'), authentication.checkForForbiddenFields(['hidden'], ['canEditUser']), function(request, response) {
         userController.updateUser(request.params.id, request.body, request.headers['x-forwarded-email'])
             .then(responseHandler.sendSuccessfulPutJsonResponse(response))
             .catch(responseHandler.sendErrorResponse(response));

--- a/app/common/dbControl.routes.js
+++ b/app/common/dbControl.routes.js
@@ -432,7 +432,7 @@ function addAttributes() {
             name: 'canEditOffice'
         },
         {
-            name: 'canViewProfile',
+            name: 'canViewUser',
             hiddenFields: [
                 'personalIdNumber',
                 'foodPreferences',
@@ -445,13 +445,13 @@ function addAttributes() {
             ]
         },
         {
-            name: 'canEditProfile'
+            name: 'canEditUser'
         }
     ];
 
     userAttributes = [
         'canViewOffice',
-        'canViewProfile'
+        'canViewUser'
     ];
 
     return Promise.all(applyAddOnItemsRec(allAttributes, 0, attributeController.createNewAttribute));

--- a/app/middleware/authentication.middleware.js
+++ b/app/middleware/authentication.middleware.js
@@ -5,7 +5,7 @@
  */
 var responseHandler = require('../utils/response.handler');
 var authenticationHandler = require('../utils/authentication.handler');
-
+var utils = require('../utils/utils');
 var Promise = require('bluebird');
 
 // middleware
@@ -24,7 +24,6 @@ exports.authentication = function(request, response, next) {
 
 exports.isAllowedOrSelf = function(attribute) {
     return function(request, response, next) {
-
         return authenticationHandler.isSelf(request.headers['x-forwarded-email'], request.params.id)
             .then(function(result) {
                 if (result) {
@@ -50,3 +49,25 @@ exports.isAllowed = function(attribute) {
             .catch(responseHandler.sendUnauthorizedResponse(response));
     };
 };
+
+exports.checkForForbiddenFields = function(forbiddenFields, requiredAttributes) {
+    return function(request, response, next) {
+        return utils.objectContainsAtLeastOneOfFields(request.body, forbiddenFields)
+            .then(function(result) {
+                if (!result) {
+                    return next();
+                } else {
+                    return authenticationHandler.getUserAttributeObjects(request.headers['x-forwarded-email'])
+                        .then(utils.extractRelevantAttributes(requiredAttributes))
+                        .then(function(relevantAttributes) {
+                            if (relevantAttributes.length > 0) {
+                                return next();
+                            } else {
+                                responseHandler.sendUnauthorizedResponse(response)();
+                            }
+                        });
+                }
+            });
+    };
+};
+

--- a/app/middleware/authentication.middleware.js
+++ b/app/middleware/authentication.middleware.js
@@ -52,7 +52,7 @@ exports.isAllowed = function(attribute) {
 
 exports.checkForForbiddenFields = function(forbiddenFields, requiredAttributes) {
     return function(request, response, next) {
-        return utils.objectContainsAtLeastOneOfFields(request.body, forbiddenFields)
+        return utils.objectContainsOneOfFields(request.body, forbiddenFields)
             .then(function(result) {
                 if (!result) {
                     return next();

--- a/app/middleware/authentication.middleware.js
+++ b/app/middleware/authentication.middleware.js
@@ -63,7 +63,11 @@ exports.checkForForbiddenFields = function(forbiddenFields, requiredAttributes) 
                             if (relevantAttributes.length > 0) {
                                 return next();
                             } else {
-                                responseHandler.sendUnauthorizedResponse(response)();
+                                forbiddenFields.forEach(function(forbiddenField) {
+                                    delete request.body[forbiddenField];
+                                });
+
+                                return next();
                             }
                         });
                 }

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -83,6 +83,51 @@ exports.sortListByProperty = function(list, prop) {
     });
 };
 
+exports.rejectIfEmpty = function(body) {
+    return function(list) {
+        return new Promise(function(resolve, reject) {
+            if (list.length <= 0) {
+                return reject();
+            } else {
+                return resolve(body);
+            }
+        });
+    };
+};
+
+exports.objectContainsAtLeastOneOfFields = function(object, fields) {
+    return new Promise(function(resolve, reject) {
+        var contains = false;
+        for (var field in object) {
+            if (fields.indexOf(field) >= 0) {
+                contains = true;
+            }
+        }
+
+        resolve(contains);
+    });
+};
+
+exports.extractRelevantAttributes = function(relevantAttributes) {
+    return function(presentAttributes) {
+        return new Promise(function(resolve, reject) {
+            if (presentAttributes.length <= 0) {
+                return reject();
+            }
+
+            var list = [];
+            presentAttributes.forEach(function(presentAttribute) {
+                if (relevantAttributes.indexOf(presentAttribute.name) >= 0) {
+                    list.push(presentAttribute);
+                }
+            });
+
+            return Promise.all(list)
+                .then(resolve);
+        });
+    };
+};
+
 // HELPER
 // ============================================================================
 

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -95,7 +95,7 @@ exports.rejectIfEmpty = function(body) {
     };
 };
 
-exports.objectContainsAtLeastOneOfFields = function(object, fields) {
+exports.objectContainsOneOfFields = function(object, fields) {
     return new Promise(function(resolve, reject) {
         var contains = false;
         for (var field in object) {


### PR DESCRIPTION
This fields holds a boolean for if the user is a hidden user.

Any user with the attribute 'canEditUser' will see this user in both getAllUsers and getUserById.
Any user without the attribute 'canEditUser' will see this user in neither getAllUsers nor getUserById.
The hidden user will see himself by a getUserById or getCurrentUser, but not in getAllUsers.
A user that has both the 'canEditUser' attribute and is hidden will see himself in getAllUsers, getCurrentUser and getUserById.

Only users with the attribute 'canEditProfile' can issue a put request to change the value of the hidden field on a user. If the user issuing the put request isn't authorized to change a field, the field is removed from the request and the remaining fields are used in the request. Added 'email' and 'role' as forbidden fields. 

The default value for the hidden field is 'false'.

Also added trimming for hiddenFields in getAllUsers
