### PR TITLE
Remove null check from extend method in utils.

### DIFF
--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -4,7 +4,7 @@ var Promise = require('bluebird');
 
 exports.extend = function(destination, source) {
     for (var prop in destination) {
-        if (destination.hasOwnProperty(prop) && source.hasOwnProperty(prop) && source[prop] !== null) {
+        if (destination.hasOwnProperty(prop) && source.hasOwnProperty(prop)) {
             destination[prop] = source[prop];
         }
     }


### PR DESCRIPTION
Checking for null is not needed, since only the properties currently set on the object will be saved.
This allows saving null values for properties when they're needed/wanted.
